### PR TITLE
Fix sudo issue with udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ After purchasing a [Logitech Litra Glow](https://www.logitech.com/en-us/products
 ### Linux
 ```bash
 # If necessary, create a udev role to grant permission to access the light
-sudo echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c900",\
-           MODE="0666"' > /etc/udev/rules.d/82-litra-glow.rules
+sudo tee /etc/udev/rules.d/82-litra-glow.rules <<< 'SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c900",MODE="0666"'
 
 sudo reboot
 


### PR DESCRIPTION
`sudo command > outfile` runs command with elevated permissions. But it doesn't have any effect on the permissions that `outfile` is written with as redirecting the output is handled by the shell which hasn't been elevated.

Which is why I received this error
```
$ sudo echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c900",\
           MODE="0666"' > /etc/udev/rules.d/82-litra-glow.rules
bash: /etc/udev/rules.d/82-litra-glow.rules: Permission denied
```

Using `tee` is a common solution to this problem.