### PR TITLE
Add support for Litra Beam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .tox
 pdoc3-html
 .coverage
+build

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Introduction
 
-After purchasing a [Logitech Litra Glow](https://www.logitech.com/en-us/products/lighting/litra-glow.946-000001.html) I was unable to find any support for linux. This project reverse-engineers the basic functionality of the litra pro so that we can control it via USB without using the physical buttons on the device.
+After purchasing a [Logitech Litra Glow](https://www.logitech.com/en-us/products/lighting/litra-glow.946-000001.html) I was unable to find any support for linux. This project reverse-engineers the basic functionality of the litra gloq so that we can control it via USB without using the physical buttons on the device. It also now supports the [Logitech Litra Beam](https://www.logitech.com/en-us/products/lighting/litra-beam.946-000006.html).
 
 ## Quick Start
 
@@ -11,6 +11,7 @@ After purchasing a [Logitech Litra Glow](https://www.logitech.com/en-us/products
 ```bash
 # If necessary, create a udev role to grant permission to access the light
 sudo tee /etc/udev/rules.d/82-litra-glow.rules <<< 'SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c900",MODE="0666"'
+sudo tee /etc/udev/rules.d/82-litra-glow.rules <<< 'SUBSYSTEM=="usb", ATTR{idVendor}=="046d", ATTR{idProduct}=="c901",MODE="0666"'
 
 sudo reboot
 

--- a/src/llgd/config/llgd_config.py
+++ b/src/llgd/config/llgd_config.py
@@ -8,7 +8,6 @@ logging.basicConfig(
     format='%(asctime)s [%(levelname)s] %(message)s', level=getenv('LITRA_LOGLEVEL',
                                                                    default='WARNING'))
 
-
 class LlgdConfig:
     """This class allows the state of the light along with custom profiles
     to be persisted into a user config file

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ deps =
     pylint
     flake8
 commands =
-    python -m pylint --rcfile=setup.cfg src/
+    python -m pylint --rcfile=setup.cfg --disable=C src.version src/
     flake8 src/ --count --select=E9,F63,F7,F82 --show-source --statistics
 
 [testenv:bandit]


### PR DESCRIPTION
Updated code to support multiple device IDs so that the Litra Beam could be added.  I do not own this light so currently assuming it has the same USB specification as the Litra Glow. Addresses issue #21 