### PR TITLE
add dependency for Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sudo dnf install -y python3-tkinter libappindicator-gtk3
 The following dependencies may need to be installed for the UI. This was specifically noted on ubuntu 20.04:
 
 ```bash
-sudo apt-get install -y python3-tk
+sudo apt-get install -y python3-tk gir1.2-appindicator3-0.1
 ```
 
 ## The UI


### PR DESCRIPTION
Without this dependency I got

```
$ lcui
Traceback (most recent call last):
  File "/home/tverbeke/.local/bin/lcui", line 5, in <module>
    from llgd.ui.__main__ import main
  File "/home/tverbeke/.local/lib/python3.8/site-packages/llgd/ui/__main__.py", line 5, in <module>
    from psgtray import SystemTray  # pylint: disable=import-error
  File "/home/tverbeke/.local/lib/python3.8/site-packages/psgtray/__init__.py", line 2, in <module>
    from .psgtray import *
  File "/home/tverbeke/.local/lib/python3.8/site-packages/psgtray/psgtray.py", line 1, in <module>
    import pystray, io, base64, threading, time
  File "/home/tverbeke/.local/lib/python3.8/site-packages/pystray/__init__.py", line 48, in <module>
    Icon = backend().Icon
  File "/home/tverbeke/.local/lib/python3.8/site-packages/pystray/__init__.py", line 40, in backend
    return importlib.import_module(__package__ + '._' + module)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/tverbeke/.local/lib/python3.8/site-packages/pystray/_appindicator.py", line 22, in <module>
    gi.require_version('AppIndicator3', '0.1')
  File "/usr/lib/python3/dist-packages/gi/__init__.py", line 129, in require_version
    raise ValueError('Namespace %s not available' % namespace)
```
After `sudo apt install gir1.2-appindicator3-0.1` I could run the `lcui` command without issues

