### PR TITLE
Add support for Litra Beam LX

### DIFF
--- a/src/llgd/lib/llgd_lib.py
+++ b/src/llgd/lib/llgd_lib.py
@@ -18,6 +18,11 @@ LITRA_PRODUCTS = [{'name': 'Glow',
                    'id': 0xc901,
                    'endpoint': 0x01,
                    'buffer_length': 32},
+                  
+                  {'name': 'Beam LX',
+                   'id': 0xc903,
+                   'endpoint': 0x1,
+                   'buffer_length': 32},
                   ]
 
 LIGHT_OFF = 0x00


### PR DESCRIPTION
As discussed in #33 already, `litra-driver` does currently not support the Litra Beam LX.
I've found and added the vidpid of the LX and it is now finding it, however command still seem to do nothing.

If someone could point me in a direction as to how to reverse engineer/find the needed endpoints on the LX I'd be happy to contribute this part of the implementation as well.

@Josh0711 @kharyam 